### PR TITLE
Fix Vue warning related to the toggle components

### DIFF
--- a/components/header.vue
+++ b/components/header.vue
@@ -15,19 +15,23 @@ const user = useCurrentUser();
                     class="basis-[90px]">
                     <ModulesLogout />
                 </div>
-                <ThemeToggle class="p-2" />
-                <LanguageToggle class="p-2">
-                    <template #english>
-                        <Icon
-                            class="size-6"
-                            name="emojione:flag-for-us-outlying-islands" />
-                    </template>
-                    <template #german>
-                        <Icon
-                            class="size-6"
-                            name="emojione:flag-for-germany" />
-                    </template>
-                </LanguageToggle>
+                <div class="p-2">
+                    <ThemeToggle />
+                </div>
+                <div class="p-2">
+                    <LanguageToggle>
+                        <template #english>
+                            <Icon
+                                class="size-6"
+                                name="emojione:flag-for-us-outlying-islands" />
+                        </template>
+                        <template #german>
+                            <Icon
+                                class="size-6"
+                                name="emojione:flag-for-germany" />
+                        </template>
+                    </LanguageToggle>
+                </div>
             </div>
         </UiContainer>
     </UiNavbar>


### PR DESCRIPTION
This change prevents extraneous attributes from being passed to fragment or text root nodes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Reorganized the layout of the header components for improved structure and positioning.
  - Adjusted placement of `ThemeToggle` and `LanguageToggle` components for better accessibility and visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->