### PR TITLE
Modify CI workflow to only trigger on pull requests to main

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -12,8 +12,6 @@ env:
     API_URL: ${{ secrets.API_URL }}
 
 on:
-    push:
-        branches: [main]
     pull_request:
         branches: [main]
 


### PR DESCRIPTION
Deployment happens on Firebase side. Therefore,
there is no need to run an extra build after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated CI workflow to trigger only on pull requests to the `main` branch, improving efficiency and focusing on relevant changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->